### PR TITLE
Return 413 on maxBytes error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -161,7 +161,7 @@ exports.Dispenser = internals.Dispenser = function (options) {
         this._bytes += Buffer.byteLength(data);
 
         if (this._bytes > this._maxBytes) {
-            finish(Boom.badRequest('Maximum size exceeded'));
+            finish(Boom.entityTooLarge('Maximum size exceeded'));
         }
     };
 

--- a/test/index.js
+++ b/test/index.js
@@ -525,6 +525,7 @@ describe('Dispenser', () => {
 
             expect(err).to.exist();
             expect(err.message).to.equal('Maximum size exceeded');
+            expect(err.output.statusCode).to.equal(413);
             team.attend();
         });
 


### PR DESCRIPTION
See https://github.com/hapijs/hapi/issues/3509.

I consider this a bug, but it could also be seen as a breaking change. Fine either way.