### PR TITLE
bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "devDependencies": {
     "@hapi/code": "8.x.x",
     "@hapi/lab": "24.x.x",
-    "@hapi/teamwork": "4.x.x",
+    "@hapi/teamwork": "5.x.x",
     "@hapi/wreck": "17.x.x",
-    "form-data": "3.x.x"
+    "form-data": "4.x.x"
   },
   "scripts": {
     "test": "lab -t 100 -L -a @hapi/code",


### PR DESCRIPTION
Bumped hapi/teamwork and form-data to their next major versions, respectively.

This change was prompted by the deprecation warnings produced by hapi/teamwork, which was stuck on v4 (which is deprecated).

Tests pass (before and) after the change.