### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -10,3 +10,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
-Copyright (c) 2014-2020, Sideway Inc, and project contributors  
-Copyright (c) 2014, Walmart.  
-Copyright (c) 2011-2013 Felix Geisendörfer, Andrew Kelley  
+Copyright (c) 2014-2022, Project contributors
+Copyright (c) 2014-2020, Sideway Inc
+Copyright (c) 2014, Walmart.
+Copyright (c) 2011-2013 Felix Geisendörfer, Andrew Kelley
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@ internals.defaults = {
 };
 
 
-exports.Dispenser = internals.Dispenser = class extends Stream.Writable {
+exports.Dispenser = class extends Stream.Writable {
 
     constructor(options) {
 
@@ -77,10 +77,10 @@ exports.Dispenser = internals.Dispenser = class extends Stream.Writable {
         this._parts = new Nigel.Stream(Buffer.from('--' + settings.boundary));
         this._lines = new Nigel.Stream(Buffer.from('\r\n'));
 
-        this._parts.on('needle', () => this._onPartEnd());
-        this._parts.on('haystack', (chunk) => this._onPart(chunk));
-        this._lines.on('needle', () => this._onLineEnd());
-        this._lines.on('haystack', (chunk) => this._onLine(chunk));
+        this._parts.on('needle', () => this.#onPartEnd());
+        this._parts.on('haystack', (chunk) => this.#onPart(chunk));
+        this._lines.on('needle', () => this.#onLineEnd());
+        this._lines.on('haystack', (chunk) => this.#onLine(chunk));
         this.once('finish', () => this._parts.end());
         this._parts.once('close', () => this._lines.end());
 
@@ -94,10 +94,10 @@ exports.Dispenser = internals.Dispenser = class extends Stream.Writable {
             }
 
             if (err) {
-                return this._abort(err);
+                return this.#abort(err);
             }
 
-            this._emit('close');
+            this.#emit('close');
         };
 
         finish = Hoek.once(finish);
@@ -106,20 +106,20 @@ exports.Dispenser = internals.Dispenser = class extends Stream.Writable {
 
             if (this._state === internals.state.epilogue) {
                 if (this._held) {
-                    this._emit('epilogue', this._held);
+                    this.#emit('epilogue', this._held);
                     this._held = '';
                 }
             }
             else if (this._state === internals.state.boundary) {
                 if (!this._held) {
-                    this._abort(Boom.badRequest('Missing end boundary'));
+                    this.#abort(Boom.badRequest('Missing end boundary'));
                 }
                 else if (this._held !== '--') {
-                    this._abort(Boom.badRequest('Only white space allowed after boundary at end'));
+                    this.#abort(Boom.badRequest('Only white space allowed after boundary at end'));
                 }
             }
             else {
-                this._abort(Boom.badRequest('Incomplete multipart payload'));
+                this.#abort(Boom.badRequest('Incomplete multipart payload'));
             }
 
             setImmediate(finish);                  // Give pending events a chance to fire
@@ -158,7 +158,7 @@ exports.Dispenser = internals.Dispenser = class extends Stream.Writable {
         return next();
     }
 
-    _emit(...args) {
+    #emit(...args) {
 
         if (this._error) {
             return;
@@ -167,13 +167,13 @@ exports.Dispenser = internals.Dispenser = class extends Stream.Writable {
         this.emit(...args);
     }
 
-    _abort(err) {
+    #abort(err) {
 
-        this._emit('error', err);
+        this.#emit('error', err);
         this._error = err;
     }
 
-    _onPartEnd() {
+    #onPartEnd() {
 
         this._lines.flush();
 
@@ -184,10 +184,10 @@ exports.Dispenser = internals.Dispenser = class extends Stream.Writable {
                 if (this._held[last] !== '\n' ||
                     this._held[last - 1] !== '\r') {
 
-                    return this._abort(Boom.badRequest('Preamble missing CRLF terminator'));
+                    return this.#abort(Boom.badRequest('Preamble missing CRLF terminator'));
                 }
 
-                this._emit('preamble', this._held.slice(0, -2));
+                this.#emit('preamble', this._held.slice(0, -2));
                 this._held = '';
             }
 
@@ -201,13 +201,13 @@ exports.Dispenser = internals.Dispenser = class extends Stream.Writable {
             this._stream = null;
         }
         else if (this._name) {
-            this._emit('field', this._name, this._held);
+            this.#emit('field', this._name, this._held);
             this._name = '';
             this._held = '';
         }
     }
 
-    _onPart(chunk) {
+    #onPart(chunk) {
 
         if (this._state === internals.state.preamble) {
             this._held = this._held + chunk.toString();
@@ -225,7 +225,7 @@ exports.Dispenser = internals.Dispenser = class extends Stream.Writable {
         }
     }
 
-    _onLineEnd() {
+    #onLineEnd() {
 
         // Boundary whitespace
 
@@ -240,7 +240,7 @@ exports.Dispenser = internals.Dispenser = class extends Stream.Writable {
                         return;
                     }
 
-                    return this._abort(Boom.badRequest('Only white space allowed after boundary'));
+                    return this.#abort(Boom.badRequest('Only white space allowed after boundary'));
                 }
             }
 
@@ -263,7 +263,7 @@ exports.Dispenser = internals.Dispenser = class extends Stream.Writable {
                     this._held[0] === '\t') {
 
                     if (!this._pendingHeader) {
-                        return this._abort(Boom.badRequest('Invalid header continuation without valid declaration on previous line'));
+                        return this.#abort(Boom.badRequest('Invalid header continuation without valid declaration on previous line'));
                     }
 
                     this._pendingHeader = this._pendingHeader + ' ' + this._held.slice(1);                       // Drop tab
@@ -273,7 +273,7 @@ exports.Dispenser = internals.Dispenser = class extends Stream.Writable {
 
                 // Start of new header
 
-                this._flushHeader();
+                this.#flushHeader();
                 this._pendingHeader = this._held;
                 this._held = '';
 
@@ -282,7 +282,7 @@ exports.Dispenser = internals.Dispenser = class extends Stream.Writable {
 
             // End of headers
 
-            this._flushHeader();
+            this.#flushHeader();
 
             this._state = internals.state.payload;
 
@@ -292,7 +292,7 @@ exports.Dispenser = internals.Dispenser = class extends Stream.Writable {
                 disposition = Content.disposition(this._headers['content-disposition']);
             }
             catch (err) {
-                return this._abort(err);
+                return this.#abort(err);
             }
 
             if (disposition.filename !== undefined) {
@@ -313,7 +313,7 @@ exports.Dispenser = internals.Dispenser = class extends Stream.Writable {
                 stream.filename = disposition.filename;
                 stream.headers = this._headers;
                 this._headers = {};
-                this._emit('part', stream);
+                this.#emit('part', stream);
             }
             else {
                 this._name = disposition.name;
@@ -328,7 +328,7 @@ exports.Dispenser = internals.Dispenser = class extends Stream.Writable {
         this._held = this._held + '\r\n';                               // Put the new line back
     }
 
-    _onLine(chunk) {
+    #onLine(chunk) {
 
         if (this._stream) {
             this._stream.write(chunk);                      // Stream payload
@@ -338,7 +338,7 @@ exports.Dispenser = internals.Dispenser = class extends Stream.Writable {
         }
     }
 
-    _flushHeader() {
+    #flushHeader() {
 
         if (!this._pendingHeader) {
             return;
@@ -347,16 +347,16 @@ exports.Dispenser = internals.Dispenser = class extends Stream.Writable {
         const sep = this._pendingHeader.indexOf(':');
 
         if (sep === -1) {
-            return this._abort(Boom.badRequest('Invalid header missing colon separator'));
+            return this.#abort(Boom.badRequest('Invalid header missing colon separator'));
         }
 
         if (!sep) {
-            return this._abort(Boom.badRequest('Invalid header missing field name'));
+            return this.#abort(Boom.badRequest('Invalid header missing field name'));
         }
 
         const name = this._pendingHeader.slice(0, sep).toLowerCase();
         if (name === '__proto__') {
-            return this._abort(Boom.badRequest('Invalid header'));
+            return this.#abort(Boom.badRequest('Invalid header'));
         }
 
         this._headers[name] = this._pendingHeader.slice(sep + 1).trim();

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@hapi/boom": "^10.0.0",
     "@hapi/content": "^6.0.0",
     "@hapi/hoek": "^10.0.0",
-    "@hapi/nigel": "^4.0.0"
+    "@hapi/nigel": "^5.0.0"
   },
   "devDependencies": {
     "@hapi/code": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -18,18 +18,18 @@
     ]
   },
   "dependencies": {
-    "@hapi/b64": "5.x.x",
-    "@hapi/boom": "9.x.x",
-    "@hapi/content": "^5.0.2",
-    "@hapi/hoek": "9.x.x",
-    "@hapi/nigel": "4.x.x"
+    "@hapi/b64": "^6.0.0",
+    "@hapi/boom": "^10.0.0",
+    "@hapi/content": "^6.0.0",
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/nigel": "^4.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x",
-    "@hapi/teamwork": "5.x.x",
-    "@hapi/wreck": "17.x.x",
+    "@hapi/lab": "^25.0.1",
+    "@hapi/teamwork": "^6.0.0",
+    "@hapi/wreck": "^18.0.0",
     "form-data": "4.x.x"
   },
   "scripts": {

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Pez;
+
+    before(async () => {
+
+        Pez = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Pez)).to.equal([
+            'Dispenser',
+            'default'
+        ]);
+    });
+});


### PR DESCRIPTION
 - Test on node v14+, adopt some new syntax.
 - Update to node v18-compatible versions of hapi modules.
 - Ensure all exports are available when used as ESM module.

If this looks good, this will go out as pez v6.